### PR TITLE
Adds a warning message when ad blockers are detected

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/_config.yml
+++ b/_config.yml
@@ -48,4 +48,4 @@ google_tag_manager:
 
 adblocker_warning:
   enabled: false
-  message: We use Google Analytics to improve our website. Please configure your ad blocker to allow tracking on this website.
+  message: We use Google Analytics to improve our website. Please add this website to your ad blocker allowlist.

--- a/_config.yml
+++ b/_config.yml
@@ -45,3 +45,7 @@ kramdown:
 google_analytics:
 # Google Tag Manager token, get it code here https://tagmanager.google.com
 google_tag_manager:
+
+adblocker_warning:
+  enabled: false
+  message: We use Google Analytics to improve our website. Please configure your ad blocker to allow tracking on this website.

--- a/_includes/adblocker-warning.html
+++ b/_includes/adblocker-warning.html
@@ -1,6 +1,6 @@
 {% if include.message %}
-<div id="adblocker-warning" class="sticky text-center top-0 w-full z-10 bg-theme-adblocker-warning-bg">
-    <div class="py-2 text-theme-adblocker-warning-text">
+<div id="adblocker-warning" class="sticky text-center top-0 w-full z-10 bg-theme-adblocker-warning-bg hidden">
+    <div class="p-2 text-theme-adblocker-warning-text">
         {{ include.message }}
     </div>
 </div>

--- a/_includes/adblocker-warning.html
+++ b/_includes/adblocker-warning.html
@@ -1,0 +1,7 @@
+{% if include.message %}
+<div id="adblocker-warning" class="sticky text-center top-0 w-full z-10 bg-theme-adblocker-warning-bg">
+    <div class="py-2 text-theme-adblocker-warning-text">
+        {{ include.message }}
+    </div>
+</div>
+{% endif %}

--- a/_includes/adblocker-warning.html
+++ b/_includes/adblocker-warning.html
@@ -1,5 +1,5 @@
 {% if include.message %}
-<div id="adblocker-warning" class="sticky text-center top-0 w-full z-10 bg-theme-adblocker-warning-bg hidden">
+<div id="adblocker-warning" class="text-center bg-theme-adblocker-warning-bg hidden">
     <div class="p-2 text-theme-adblocker-warning-text">
         {{ include.message }}
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,7 @@
 <div class="sticky top-0 z-10 w-full min-h-[100px]">
+  {% if site.adblocker_warning.enabled %}
+    {% include adblocker-warning.html message=site.adblocker_warning.message %}
+  {% endif %}
   <!-- HEADER NAVBAR -->
   <div class="flex items-center justify-between px-4 py-4 sm:px-6 md:justify-start md:space-x-10 bg-theme-header-bg min-h-[100px]">
     <!-- SITE LOGO -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,9 +6,6 @@
     {% include google-tag-manager-body.html %}
     {% endif %}
     {% include offcanvas.html %}
-    {% if site.adblocker_warning.enabled %}
-    {% include adblocker-warning.html message=site.adblocker_warning.message %}
-    {% endif %}
     {% include header.html %}
     {% include content.html %}
   </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,9 @@
     {% include google-tag-manager-body.html %}
     {% endif %}
     {% include offcanvas.html %}
+    {% if site.adblocker_warning.enabled %}
+    {% include adblocker-warning.html message=site.adblocker_warning.message %}
+    {% endif %}
     {% include header.html %}
     {% include content.html %}
   </body>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -225,6 +225,33 @@ function initMobileNavigation() {
   });
 }
 
+function initAdBlockerWarning() {
+  // Create a fake ad elment
+  const ad = document.createElement('ins');
+  ad.className = 'AdSense';
+  ad.style.display = 'block';
+  ad.style.position = 'absolute';
+  ad.style.top = '-1px';
+  ad.style.height = '1px';
+  document.body.appendChild(ad);
+
+  // Adding a timeout so adblockers have time to hide the ad element
+  window.setTimeout(function() {
+    // When an adblocker is enabled the ad will be have no height
+    var isAdBlockEnabled = !ad.clientHeight;
+    document.body.removeChild(ad);
+
+    // Show/hide the warning message
+    const adblockerWarning = document.getElementById('adblocker-warning');
+    if(adblockerWarning && isAdBlockEnabled){
+      adblockerWarning.classList.toggle('hidden');
+    }
+
+  }, 400);
+
+  return isAdBlockEnabled;
+}
+
 flt.onReady(function () {
   initLazyLoadImages();
   initSideMenuNavigation();
@@ -233,5 +260,8 @@ flt.onReady(function () {
   initHierarchyTree();
   {% if site.site_search %}
   initSearch();
+  {% endif %}
+  {% if site.adblocker_warning.enabled %}
+  initAdBlockerWarning();
   {% endif %}
 })

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -247,7 +247,7 @@ function initAdBlockerWarning() {
       adblockerWarning.classList.toggle('hidden');
     }
 
-  }, 400);
+  }, 200);
 
   return isAdBlockEnabled;
 }

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -247,9 +247,7 @@ function initAdBlockerWarning() {
       adblockerWarning.classList.toggle('hidden');
     }
 
-  }, 200);
-
-  return isAdBlockEnabled;
+  }, 1000);
 }
 
 flt.onReady(function () {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,8 @@ module.exports = {
         'theme-header-support-button-bg-hover': '#3CA8EF',
         'theme-mobile-menu-icon': '#FFFFFF',
         'theme-mobile-menu-icon-hover': '#3CA8EF',
+        'theme-adblocker-warning-bg': '#3CA8EF',
+        'theme-adblocker-warning-text': '#FFFFFF'
       },
       typography: (theme) => ({
         DEFAULT: {


### PR DESCRIPTION
Adds functionality to detect when someone is using an ad blocker and shows a warning message on the header.

You can enable/disable it and change the message in the configuration:

```yml
# _config.yml
adblocker_warning:
  enabled: false
  message: We use Google Analytics to improve our website. Please add this website to your ad blocker allowlist.
```

Background and text colors can be changed in the tailwind configuration file:
```javascript
// tailwind.config.js
 theme: {
    extend: {
      colors: {
        [ ... ]
        'theme-adblocker-warning-bg': '#3CA8EF',
        'theme-adblocker-warning-text': '#FFFFFF'
      },
```

Example:

![image](https://user-images.githubusercontent.com/106069684/174276877-97748f13-9bfe-487b-9def-c6f63a733cd6.png)
